### PR TITLE
Don't dynamically allocate TimerTask

### DIFF
--- a/mvm-sm-yakindu/src-gen/CPPTimerInterface.cpp
+++ b/mvm-sm-yakindu/src-gen/CPPTimerInterface.cpp
@@ -1,103 +1,85 @@
 #include "TimedStatemachineInterface.h"
 #include "CPPTimerinterface.h"
+#include <algorithm>
+
+// the following assumes a timer with a null state machine handle is not valid
+static bool is_valid(TimerTask const& timer)
+{
+    return timer.getHandle() != nullptr;
+}
 
 /*!
-	This function will be called for each time event that is relevant for a state when a state will be entered.
-	\param evid An unique identifier of the event.
-	\time_ms The time in milli seconds
-	\periodic Indicates the the time event must be raised periodically until the timer is unset
+    This function will be called for each time event that is relevant for a state when a state will be entered.
+    \param evid An unique identifier of the event.
+    \time_ms The time in milli seconds
+    \periodic Indicates the the time event must be raised periodically until the timer is unset
 */
 void CPPTimerInterface::setTimer( TimedStatemachineInterface* statemachine,
-		sc_eventid event,
-		sc_integer time,
-		sc_boolean isPeriodic )
+        sc_eventid event,
+        sc_integer time,
+        sc_boolean isPeriodic )
 {
-
-	/* create new task and go through all timers ... */
-	TimerTask* task = new TimerTask(statemachine, event, time, isPeriodic);
-	for (int i = 0; i < MAX_TIMER; i++)
-	{
-
-		/* ... and find an unused one. */
-		if(this->tasks[i] == sc_null)
-		{
-
-			/* set timer properties */
-			this->tasks[i] = task;
-			break;
-		}
-	}
+    auto const it = std::find_if(
+        tasks,
+        tasks + MAX_TIMER,
+        [] (TimerTask const& t) { return !is_valid(t); }
+    );
+    if (it != tasks + MAX_TIMER) {
+        *it = TimerTask{statemachine, event, time, isPeriodic};
+    } else{
+        // no free slots (abort?)
+    }
 }
 
 /*!
-	This function will be called for each time event that is relevant for a state when a state will be left.
-	\param evid An unique identifier of the event.
+    This function will be called for each time event that is relevant for a state when a state will be left.
+    \param evid An unique identifier of the event.
 */
 void CPPTimerInterface::unsetTimer(TimedStatemachineInterface* statemachine,
-		sc_eventid event)
+        sc_eventid event)
 {
-
-	/* go through all timers ... */
-	for(int i = 0; i < MAX_TIMER; i++)
-	{
-
-		TimerTask *task = this->tasks[i];
-		/* ... and find the used timer */
-		if((task != sc_null) && (task->getPtEvid() == event))
-		{
-
-			/* reset the timer */
-			delete this->tasks[i];
-			this->tasks[i] = sc_null;
-		}
-	}
+    auto const it = std::find_if(
+        tasks,
+        tasks + MAX_TIMER,
+        [=] (TimerTask const& t) { return is_valid(t) && t.getPtEvid() == event; }
+    );
+    if (it != tasks + MAX_TIMER) {
+        *it = TimerTask{};
+    }
 }
 
 
 /*!
-	This function must be called by the user. The elapsed time must be calculated every time, the function gets
-	gets called.
+    This function must be called by the user. The elapsed time must be calculated every time, the function gets
+    gets called.
  */
-int n = 0;
 void CPPTimerInterface::updateActiveTimer(TimedStatemachineInterface* statemachine,
-		long elapsed_ms)
+        long elapsed_ms)
 {
+    for (auto& task : tasks) {
+        if (is_valid(task))
+        {
+            task.updateElapsedTimeMs(elapsed_ms);
 
-	/* go through all timers ... */
-	for (int i = 0; i < MAX_TIMER; i++)
-	{
+            /* raise Time Event if the timer has proceed */
+            if (task.getElapsedTimeMs() >= task.getTimeMs())
+            {
+                // assert(statemachine == task.getHandle());
+                /* raise time event */
+                statemachine->raiseTimeEvent(task.getPtEvid());
 
-		/* ... and process all used */
-		TimerTask *task = this->tasks[i];
-		if (task != sc_null)
-		{
-			task->updateElapsedTimeMs(elapsed_ms);
-
-			/* raise Time Event if the timer has proceed */
-			if (task->getElapsedTimeMs() >= task->getTimeMs())
-			{
-
-				/* raise time event */
-				statemachine->raiseTimeEvent(task->getPtEvid());
-
-				/* update periodic timer */
-				if (task->isPeriodic())
-				{
-					task->setElapsedTimeMs(task->getElapsedTimeMs()-task->getTimeMs());
-				}
-			}
-		}
-	}
+                /* update periodic timer */
+                if (task.isPeriodic())
+                {
+                    task.setElapsedTimeMs(task.getElapsedTimeMs()-task.getTimeMs());
+                }
+            }
+        }
+    }
 }
 
 /* ! Cancel timer service. */
 void CPPTimerInterface::cancel()
 {
-
-	/* delete all timers */
-	for (int i = 0; i < MAX_TIMER; i++)
-	{
-		delete tasks[i];
-		this->tasks[i] = sc_null;
-	}
+    std::fill(tasks, tasks + MAX_TIMER, TimerTask{});
 }

--- a/mvm-sm-yakindu/src-gen/CPPTimerinterface.h
+++ b/mvm-sm-yakindu/src-gen/CPPTimerinterface.h
@@ -9,112 +9,109 @@ class TimerTask {
 
 private:
 
-	/* internal arguments of a timer task */
-	sc_integer time_ms;
-	sc_boolean periodic;
-	sc_eventid pt_evid;
-	sc_integer elapsed_time_ms = 0;
-	TimedStatemachineInterface* handle;
+    /* internal arguments of a timer task */
+    sc_integer time_ms = 0;
+    sc_boolean periodic = false;
+    sc_eventid pt_evid = 0;
+    sc_integer elapsed_time_ms = 0;
+    TimedStatemachineInterface* handle = nullptr;
 
 public:
+    TimerTask() = default;
 
-	/* Constructor, which creates a new timer task */
-	TimerTask(TimedStatemachineInterface* statemachine, sc_eventid event, sc_integer time, sc_boolean isPeriodic){
-		this->handle = statemachine;
-		this->pt_evid = event;
-		this->periodic = isPeriodic;
-		this->time_ms = time;
-	}
+    /* Constructor, which creates a new timer task */
+    TimerTask(TimedStatemachineInterface* statemachine, sc_eventid event, sc_integer time, sc_boolean isPeriodic){
+        this->handle = statemachine;
+        this->pt_evid = event;
+        this->periodic = isPeriodic;
+        this->time_ms = time;
+    }
 
-	/* Destructor */
-	~TimerTask(){}
+    /* Destructor */
+    ~TimerTask(){}
 
-	/*! Getter and Setter functions. */
-	sc_integer getTimeMs() const {
-		return time_ms;
-	}
+    /*! Getter and Setter functions. */
+    sc_integer getTimeMs() const {
+        return time_ms;
+    }
 
-	void setTimeMs(sc_integer timeMs) {
-		time_ms = timeMs;
-	}
+    void setTimeMs(sc_integer timeMs) {
+        time_ms = timeMs;
+    }
 
-	sc_integer getElapsedTimeMs() const {
-		return elapsed_time_ms;
-	}
+    sc_integer getElapsedTimeMs() const {
+        return elapsed_time_ms;
+    }
 
-	void updateElapsedTimeMs(sc_integer elapsedTimeMs = 0) {
-		elapsed_time_ms += elapsedTimeMs;
-	}
+    void updateElapsedTimeMs(sc_integer elapsedTimeMs = 0) {
+        elapsed_time_ms += elapsedTimeMs;
+    }
 
-	void setElapsedTimeMs(sc_integer elapsedTimeMs = 0) {
-		elapsed_time_ms = elapsedTimeMs;
-	}
+    void setElapsedTimeMs(sc_integer elapsedTimeMs = 0) {
+        elapsed_time_ms = elapsedTimeMs;
+    }
 
-	sc_eventid getPtEvid() const {
-		return pt_evid;
-	}
+    sc_eventid getPtEvid() const {
+        return pt_evid;
+    }
 
-	void setPtEvid(sc_eventid ptEvid) {
-		pt_evid = ptEvid;
-	}
+    void setPtEvid(sc_eventid ptEvid) {
+        pt_evid = ptEvid;
+    }
 
-	sc_boolean isPeriodic() const {
-		return periodic;
-	}
+    sc_boolean isPeriodic() const {
+        return periodic;
+    }
 
-	void setPeriodic(sc_boolean periodic) {
-		this->periodic = periodic;
-	}
+    void setPeriodic(sc_boolean periodic) {
+        this->periodic = periodic;
+    }
 
-	const TimedStatemachineInterface* getHandle() const {
-		return handle;
-	}
+    const TimedStatemachineInterface* getHandle() const {
+        return handle;
+    }
 };
 
 class CPPTimerInterface : public TimerInterface{
 private:
-	// here dynamic allocation will be used to fill the tasks
-	TimerTask* tasks[MAX_TIMER];
+    // here dynamic allocation will be used to fill the tasks
+    TimerTask tasks[MAX_TIMER];
 public:
 
-	/* Constructor */
-	CPPTimerInterface(){
-		for(int i = 0; i<MAX_TIMER;i++)
-		{
-			this->tasks[i] = sc_null;
-		}
-	}
+    /* Constructor */
+    CPPTimerInterface(): tasks{} {
+    }
 
-	/* Destructor */
+    /* Destructor */
     virtual ~CPPTimerInterface()
     {
         cancel();
     }
 
     /*!
-    	This function will be called for each time event that is relevant for a state when a state will be entered.
-    	\param evid An unique identifier of the event.
-    	\time_ms The time in milli seconds
-    	\periodic Indicates the the time event must be raised periodically until the timer is unset
+        This function will be called for each time event that is relevant for a state when a state will be entered.
+        \param evid An unique identifier of the event.
+        \time_ms The time in milli seconds
+        \periodic Indicates the the time event must be raised periodically until the timer is unset
     */
     virtual void setTimer( TimedStatemachineInterface* statemachine,
-    		sc_eventid event,
-			sc_integer time,
-			sc_boolean isPeriodic );
+            sc_eventid event,
+            sc_integer time,
+            sc_boolean isPeriodic );
 
     /*!
-    	This function will be called for each time event that is relevant for a state when a state will be left.
-    	\param evid An unique identifier of the event.
+        This function will be called for each time event that is relevant for a state when a state will be left.
+        \param evid An unique identifier of the event.
     */
     virtual void unsetTimer(TimedStatemachineInterface* statemachine,
-    		sc_eventid event);
+            sc_eventid event);
 
     /*!
-    	This function must be called by the user. The elapsed time must be calculated every time, the function gets
-    	gets called.
+        This function must be called by the user. The elapsed time must be calculated every time, the function gets
+        gets called.
      */
     void updateActiveTimer(TimedStatemachineInterface* statemachine,
-    		long elapsed_ms);
+            long elapsed_ms);
 
     /* ! Cancel timer service. */
     virtual void cancel();

--- a/mvm-sm-yakindu/src-gen/MVMStateMachine.h
+++ b/mvm-sm-yakindu/src-gen/MVMStateMachine.h
@@ -4,10 +4,10 @@
 #define MVMSTATEMACHINE_H_
 
 
-#include <VentilationModes.h>
-#include "..\src\sc_types.h"
-#include "..\src\StatemachineInterface.h"
-#include "..\src\TimedStatemachineInterface.h"
+#include "src/VentilationModes.h"
+#include "src/sc_types.h"
+#include "src/StatemachineInterface.h"
+#include "src/TimedStatemachineInterface.h"
 
 /*! \file Header of the state machine 'MVMStateMachine'.
 */

--- a/mvm-sm-yakindu/src/HAL.cpp
+++ b/mvm-sm-yakindu/src/HAL.cpp
@@ -4,7 +4,7 @@
  *  Created on: 7 mag 2020
  *      Author: AngeloGargantini
  */
-#include <HAL.h>
+#include "src/HAL.h"
 #include <iostream>
 
 HAL::HAL() {

--- a/mvm-sm-yakindu/src/MVMStateMachineOCBs.cpp
+++ b/mvm-sm-yakindu/src/MVMStateMachineOCBs.cpp
@@ -1,4 +1,4 @@
-#include <MVMStateMachineOCBs.h>
+#include "src/MVMStateMachineOCBs.h"
 #include <iostream>
 
 MVMStateMachineOCBs::~MVMStateMachineOCBs() {

--- a/mvm-sm-yakindu/src/mvm_machine_run.cpp
+++ b/mvm-sm-yakindu/src/mvm_machine_run.cpp
@@ -8,9 +8,9 @@
 
 #include <iostream>
 #include <chrono>
-#include "MVMStateMachine.h"
-#include "CPPTimerInterface.h"
-#include "MVMStateMachineOCBs.h"
+#include "src-gen/MVMStateMachine.h"
+#include "src-gen/CPPTimerinterface.h"
+#include "src/MVMStateMachineOCBs.h"
 
 using namespace std;
 


### PR DESCRIPTION
TimerTask's are kept in an array of a max size by value. A TimerTask
is valid if its StateMachine handle is nullptr.

Some modifications in include directives to be able to build with
gcc on Ubuntu.